### PR TITLE
removing raven.contrib.django from settings_shared...

### DIFF
--- a/countryx/settings_shared.py
+++ b/countryx/settings_shared.py
@@ -107,7 +107,6 @@ INSTALLED_APPS = [
     'countryx.sim',
     'django_statsd',
     'django_nose',
-    'raven.contrib.django',
     'django_jenkins',
     'waffle',
     'impersonate',


### PR DESCRIPTION
 as it is also referenced in settings_staging & settings_production.

Theoretically, it should fix this staging error:
http://jenkins.ccnmtl.columbia.edu/job/countryx-staging/57/console