### PR TITLE
Fix turn management

### DIFF
--- a/countryx/sim/middleware.py
+++ b/countryx/sim/middleware.py
@@ -37,7 +37,7 @@ class GameStateMiddleware(object):
     def process_request(self, request):
         if request.path.startswith("/admin/") \
                 or request.path.startswith("/accounts") \
-                or request.path.startswith("/site_media") \
+                or request.path.startswith("/media") \
                 or request.META['SERVER_NAME'] == 'testserver':
             return  # skip it in admin otherwise we can't add a section
         self.write_lock.acquire()

--- a/countryx/templates/base.html
+++ b/countryx/templates/base.html
@@ -1,22 +1,19 @@
+{% load static %}
 {% load compress %}
 <html>
 <head><title>countryx: {% block title %}{% endblock %}</title>
 
 {% compress css %}
-    <link href="{{STATIC_URL}}css/site.css" rel="stylesheet" type="text/css" />
-    
-    <!--[if IE]>
-        <link href="{{STATIC_URL}}css/ie_fixes.css" rel="stylesheet" type="text/css" />
-    <![endif]-->
-
+    <link href="{% static 'css/site.css' %}" rel="stylesheet" />
 {% endcompress %}
 
 {% block css %}{% endblock %}
 
-{% block js %}
 {% compress js %}
-   <script type="text/javascript" src="{{STATIC_URL}}js/core.js"></script>
+   <script type="text/javascript" src="{% static 'js/core.js' %}"></script>
 {% endcompress %}
+
+{% block js %}
 {% endblock %}
 
 {% block feeds %}{% endblock %}

--- a/countryx/templates/flatpages/default.html
+++ b/countryx/templates/flatpages/default.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 {% load markup %}
-{% load thumbnail %}
 
 {% block title %}{{ flatpage.title }}{% endblock %}
 {% block masthead %}{{ flatpage.title }}{% endblock %}

--- a/countryx/templates/sim/allpaths2.html
+++ b/countryx/templates/sim/allpaths2.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load hash %}
 
 {% block js %}
  <script type="text/javascript" src="{{STATIC_URL}}js/sim_allpaths.js"></script>
@@ -76,14 +75,6 @@
 	    </td>
 	    {% for s in turns.1.states %}
 	      <td id="t1s1s{{s.state_no}}" class="transition">
-		{%comment%}
-	        <div>
-		  {% hash s.transitions "1" as transition %}
-		  {{s.transitions|hashf:"1"}}
-		  {{blah}}
-
-		</div>
-		{%endcomment%}
 	      </td>
 	    {% endfor %}
 	  </tr>

--- a/countryx/templates/sim/faculty_section_manage.html
+++ b/countryx/templates/sim/faculty_section_manage.html
@@ -8,8 +8,8 @@
    {{ block.super }}
       
    <script type="text/javascript" src="{{STATIC_URL}}admin/js/core.js"></script>
-   <script type="text/javascript" src="{{STATIC_URL}}/admin/js/calendar.js"></script>
-   <script type="text/javascript" src="{{STATIC_URL}}/admin/js/admin/DateTimeShortcuts.js"></script>
+   <script type="text/javascript" src="{{STATIC_URL}}admin/js/calendar.js"></script>
+   <script type="text/javascript" src="{{STATIC_URL}}admin/js/admin/DateTimeShortcuts.js"></script>
 {% endblock %}
 
 {% block content %}

--- a/countryx/urls.py
+++ b/countryx/urls.py
@@ -2,15 +2,9 @@ from django.conf.urls import patterns, include, url
 from django.contrib import admin
 from django.conf import settings
 from django.views.generic import TemplateView
-import os.path
-admin.autodiscover()
 
-site_media_root = os.path.join(
-    os.path.dirname(__file__),
-    "../media")
-admin_media_root = os.path.join(
-    os.path.dirname(__file__),
-    "ve/lib/python2.6/site-packages/django/contrib/admin/media")
+
+admin.autodiscover()
 
 urlpatterns = patterns(
     '',
@@ -21,10 +15,6 @@ urlpatterns = patterns(
     (r'^sim/', include('countryx.sim.urls')),
     (r'^smoketest/$', include('smoketest.urls')),
     ('^stats/', TemplateView.as_view(template_name='stats.html')),
-    (r'^site_media/(?P<path>.*)$',
-     'django.views.static.serve', {'document_root': site_media_root}),
-    (r'^admin_media/(?P<path>.*)$',
-     'django.views.static.serve', {'document_root': admin_media_root}),
     (r'^uploads/(?P<path>.*)$',
      'django.views.static.serve', {'document_root': settings.MEDIA_ROOT}),
 )


### PR DESCRIPTION
* Fixing compress warnings (hash/thumbnail)
* Removing site_media & admin_media references from urls.py. These are no longer needed.
* Fixing .js references in the faculty_section_manage.html page.
* Switching to {% static %} tag in the compress blocks in base.html.