### PR TITLE
install node_modules in current directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,10 @@ shell: ./ve/bin/python
 	$(MANAGE) shell_plus
 
 node_modules/jshint/bin/jshint:
-	npm install jshint
+	npm install jshint --prefix=.
 
 node_modules/jscs/bin/jscs:
-	npm install jscs
+	npm install jscs --prefix=.
 
 clean:
 	rm -rf ve


### PR DESCRIPTION
Otherwise, these `npm install` commands might install these to your `$HOME/node_modules` directory, if that's set up, and the commands to execute them will fail since they're in the wrong place.